### PR TITLE
Add Refresh Tokens

### DIFF
--- a/src/backend/app/routing/auth_router.py
+++ b/src/backend/app/routing/auth_router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 from app.services import AuthService
 
-from .contracts.auth_contracts import AuthenticationPayload, RegistrationPayload, TokenResponse
+from .contracts.auth_contracts import AuthenticationPayload, RegistrationPayload, TokenResponse, TokenRefreshPayload
 
 router = APIRouter(prefix="/auth")
 
@@ -10,13 +10,33 @@ async def login(
     payload: AuthenticationPayload, 
     auth_service: AuthService = Depends(AuthService)
 ):
-    token = await auth_service.authenticate(payload.email, payload.password)
-    return TokenResponse.model_construct(token=token)
+    access, refresh, expires_in = await auth_service.authenticate(payload.email, payload.password)
+    return TokenResponse.model_construct(
+        access_token=access, 
+        refresh_token=refresh,
+        expires_in=expires_in
+    )
 
 @router.post("/register")
 async def register(
     payload: RegistrationPayload, 
     auth_service: AuthService = Depends(AuthService)
 ):
-    token = await auth_service.register(payload.email, payload.username, payload.password)
-    return TokenResponse.model_construct(token=token)
+    access, refresh, expires_in = await auth_service.register(payload.email, payload.username, payload.password)
+    return TokenResponse.model_construct(
+        access_token=access, 
+        refresh_token=refresh,
+        expires_in=expires_in
+    )
+
+@router.post("/refresh")
+async def refresh(
+    payload: TokenRefreshPayload, 
+    auth_service: AuthService = Depends(AuthService)
+):
+    access, refresh, expires_in = await auth_service.refresh_access(payload.refresh_token)
+    return TokenResponse.model_construct(
+        access_token=access, 
+        refresh_token=refresh,
+        expires_in=expires_in
+    )

--- a/src/backend/app/routing/contracts/auth_contracts.py
+++ b/src/backend/app/routing/contracts/auth_contracts.py
@@ -10,4 +10,5 @@ class AuthenticationPayload(BaseModel):
     password: str
     
 class TokenResponse(BaseModel):
-    token: str
+    access_token: str
+    refresh_token: str

--- a/src/backend/app/routing/contracts/auth_contracts.py
+++ b/src/backend/app/routing/contracts/auth_contracts.py
@@ -12,3 +12,7 @@ class AuthenticationPayload(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     refresh_token: str
+    expires_in: int
+    
+class TokenRefreshPayload(BaseModel):
+    refresh_token: str

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -40,8 +40,11 @@ def get_database_connection_string(driver: Optional[str] = None) -> str:
     return f"{DRIVER}://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}"
 
 # Access tokens
-def get_token_expiration() -> int:
-    return int(os.getenv("TOKEN_EXPIRATION", "15"))
+def get_token_expiration_minutes() -> int:
+    return int(os.getenv("TOKEN_EXPIRATION_MINUTES", "10"))
+
+def get_refresh_token_expiration_days() -> int:
+    return int(os.getenv("REFRESH_TOKEN_EXPIRATION_DAYS", "7"))
 
 def get_token_secret() -> str:
     return os.getenv("TOKEN_SECRET", "secret")

--- a/src/client/src/api/AuthApi.ts
+++ b/src/client/src/api/AuthApi.ts
@@ -2,11 +2,11 @@ import BaseApi from "./BaseApi";
 import { TokenResponse } from "@contracts";
 
 class AuthApi extends BaseApi {
-    public login(email: string, password: string): Promise<TokenResponse> {
+    login(email: string, password: string): Promise<TokenResponse> {
         return this.post("login", { email, password });
     }
 
-    public register(
+    register(
         email: string,
         username: string,
         password: string

--- a/src/client/src/api/BaseApi.ts
+++ b/src/client/src/api/BaseApi.ts
@@ -1,3 +1,5 @@
+import { TokenResponse } from "@contracts";
+
 const apiEndpoint = import.meta.env.VITE_API_ENDPOINT;
 
 abstract class BaseApi {
@@ -8,22 +10,22 @@ abstract class BaseApi {
     }
 
     protected get<T>(url: string): Promise<T> {
-        return fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
-            method: "GET",
-            headers: this.get_headers(),
-        })
-            .then(this.checkUnauthorized)
-            .then((response) => response.json());
+        return this.wrapAuthorization(() =>
+            fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
+                method: "GET",
+                headers: this.get_headers(),
+            })
+        ).then((r) => r.json());
     }
 
     protected post<T>(url: string, data: any): Promise<T> {
-        return fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
-            method: "POST",
-            headers: this.get_headers(),
-            body: JSON.stringify(data),
-        })
-            .then(this.checkUnauthorized)
-            .then((response) => response.json());
+        return this.wrapAuthorization(() =>
+            fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
+                method: "POST",
+                headers: this.get_headers(),
+                body: JSON.stringify(data),
+            })
+        ).then((r) => r.json());
     }
 
     protected async postEventStream<T>(
@@ -60,73 +62,113 @@ abstract class BaseApi {
     }
 
     protected postForm<T>(url: string, data: FormData): Promise<T> {
-        return fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
-            method: "POST",
-            headers: {
-                Authorization: `Bearer ${localStorage.getItem("token")}`,
-            },
-            body: data,
-        })
-            .then(this.checkUnauthorized)
-            .then((response) => response.json());
+        return this.wrapAuthorization(() =>
+            fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${localStorage.getItem("token")}`,
+                },
+                body: data,
+            })
+        ).then((r) => r.json());
     }
 
     protected postWithoutResponse(url: string, data: any): Promise<void> {
-        return fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
-            method: "POST",
-            headers: this.get_headers(),
-            body: JSON.stringify(data),
-        })
-            .then(this.checkUnauthorized)
-            .then(() => {});
+        return this.wrapAuthorization(() =>
+            fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
+                method: "POST",
+                headers: this.get_headers(),
+                body: JSON.stringify(data),
+            })
+        ).then(() => {});
     }
 
     protected put<T>(url: string, data: any): Promise<T> {
-        return fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
-            method: "PUT",
-            headers: this.get_headers(),
-            body: JSON.stringify(data),
-        })
-            .then(this.checkUnauthorized)
-            .then((response) => response.json());
+        return this.wrapAuthorization(() =>
+            fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
+                method: "PUT",
+                headers: this.get_headers(),
+                body: JSON.stringify(data),
+            })
+        ).then((r) => r.json());
     }
 
     protected putWithoutResponse(url: string, data: any): Promise<void> {
-        return fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
-            method: "PUT",
-            headers: this.get_headers(),
-            body: JSON.stringify(data),
-        })
-            .then(this.checkUnauthorized)
-            .then(() => {});
+        return this.wrapAuthorization(() =>
+            fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
+                method: "PUT",
+                headers: this.get_headers(),
+                body: JSON.stringify(data),
+            })
+        ).then(() => {});
     }
 
     protected delete<T>(url: string): Promise<T> {
-        return fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
-            method: "DELETE",
-            headers: this.get_headers(),
-        })
-            .then(this.checkUnauthorized)
-            .then((response) => response.json());
+        return this.wrapAuthorization(() =>
+            fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
+                method: "DELETE",
+                headers: this.get_headers(),
+            })
+        ).then((r) => r.json());
     }
 
     protected deleteWithoutResponse(url: string): Promise<void> {
-        return fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
-            method: "DELETE",
-            headers: this.get_headers(),
-        })
-            .then(this.checkUnauthorized)
-            .then(() => {});
+        return this.wrapAuthorization(() =>
+            fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
+                method: "DELETE",
+                headers: this.get_headers(),
+            })
+        ).then(() => {});
     }
 
-    private checkUnauthorized = (response: Response) => {
-        if (response.status === 401) {
-            localStorage.removeItem("token");
-            window.location.reload();
+    /**
+     * Calls the request function and checks for a 401 response. If a 401 is received, access token is refreshed and the request is retried.
+     * @param request
+     */
+    private wrapAuthorization(
+        request: () => Promise<Response>
+    ): Promise<Response> {
+        return request().then((response) => {
+            if (response.status === 401) {
+                return this.refreshToken().then(() => request());
+            }
+
+            return response;
+        });
+    }
+
+    private refreshToken(): Promise<void> {
+        const refreshToken = localStorage.getItem("refreshToken");
+
+        if (!refreshToken) {
+            return Promise.reject("No refresh token");
         }
 
-        return response;
-    };
+        return this.getRefreshedToken(refreshToken).then(
+            ({ access_token, refresh_token }) => {
+                localStorage.setItem("token", access_token);
+                localStorage.setItem("refreshToken", refresh_token);
+            }
+        );
+    }
+
+    getRefreshedToken(refreshToken: string): Promise<TokenResponse> {
+        return fetch(`${apiEndpoint}/auth/refresh`, {
+            method: "POST",
+            headers: this.get_headers(),
+            body: JSON.stringify({
+                refresh_token: refreshToken,
+            }),
+        })
+            .then((r) => r.json())
+            .catch(() => {
+                if (localStorage.getItem("token")) {
+                    localStorage.removeItem("token");
+                    localStorage.removeItem("refreshToken");
+                    window.location.reload();
+                }
+            });
+    }
 
     private get_headers = () => {
         const token = localStorage.getItem("token");

--- a/src/client/src/api/contracts/TokenResponse.ts
+++ b/src/client/src/api/contracts/TokenResponse.ts
@@ -1,3 +1,5 @@
 export interface TokenResponse {
-    token: string;
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
 }

--- a/src/client/src/context/chat/ChatContext.tsx
+++ b/src/client/src/context/chat/ChatContext.tsx
@@ -100,7 +100,7 @@ Now that you've completed the onboarding process, let's get started with plannin
 
     if (!instructor || !localUser) {
         return (
-            <Center>
+            <Center h="100%">
                 <Loader size="lg" type="dots" />
             </Center>
         );

--- a/src/client/src/context/user/UserContext.tsx
+++ b/src/client/src/context/user/UserContext.tsx
@@ -66,7 +66,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
 
     if (!userDetails || !onboardingStatus) {
         return (
-            <Center>
+            <Center h="100%">
                 <Loader size="lg" type="dots" />
             </Center>
         );


### PR DESCRIPTION
This PR adds refresh token functionality to support extending the logged in user's session so they are not kicked out after the `TOKEN_EXPIRATION` period.

Redis is used as a way to store a token blacklist so when a refresh token is used, it is blacklisted from being used again. These tokens are added to a sorted set with an expiration of their remaining validity period. When retrieving the sorted set or checking for existence of a key, expired ones are purged (since Redis doesn't allow native set item expirations by default.)

The frontend `BaseApi` has been reworked to wrap calls in a promise handler that checks for a `401 Unauthorized`, in which case it will attempt a refresh and will re-run the request. This is just a precaution, as the `AuthContext` has also been updated to set a timeout for the existing token so it will proactively refresh it if the user is already on the platform.

Additionally, added a full-screen loader in `AuthContext` that returns when the authorization state is `null` (default now instead of `false`) so the rest of the app will not render components that might make other API calls before the user state is assessed.