### PR TITLE
Add Logout

### DIFF
--- a/src/backend/app/routing/autocomplete_router.py
+++ b/src/backend/app/routing/autocomplete_router.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, Depends
 from app.services import AutocompleteService
-from app.routing.middleware import token_extractor
+from app.routing.middleware import token_validator
 
 router = APIRouter(
     prefix="/autocomplete",
     dependencies=[
-        Depends(token_extractor),
+        Depends(token_validator),
     ]
 )
 

--- a/src/backend/app/routing/chat_router.py
+++ b/src/backend/app/routing/chat_router.py
@@ -2,14 +2,14 @@ import asyncio
 import uuid
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
-from app.routing.middleware import token_extractor, user_id_extractor
+from app.routing.middleware import token_validator, user_id_extractor
 from app.services import ChatService
 from .contracts.chat_contracts import ChatSessionReference, SendChatMessage
 
 router = APIRouter(
     prefix="/chat",
     dependencies=[
-        Depends(token_extractor),
+        Depends(token_validator),
         Depends(user_id_extractor)
     ]
 )

--- a/src/backend/app/routing/contracts/auth_contracts.py
+++ b/src/backend/app/routing/contracts/auth_contracts.py
@@ -14,5 +14,5 @@ class TokenResponse(BaseModel):
     refresh_token: str
     expires_in: int
     
-class TokenRefreshPayload(BaseModel):
+class RefreshTokenPayload(BaseModel):
     refresh_token: str

--- a/src/backend/app/routing/file_router.py
+++ b/src/backend/app/routing/file_router.py
@@ -1,13 +1,13 @@
 from fastapi import APIRouter, Depends, File, UploadFile
 from ai.prompts import ResumeScannerPrompt
-from app.routing.middleware import token_extractor, user_id_extractor
+from app.routing.middleware import token_validator, user_id_extractor
 
 from common.conversion.pdf_to_image import get_images_from_pdf_bytes
 
 router = APIRouter(
     prefix="/files",
     dependencies=[
-        Depends(token_extractor),
+        Depends(token_validator),
         Depends(user_id_extractor)
     ]
 )

--- a/src/backend/app/routing/instructor_router.py
+++ b/src/backend/app/routing/instructor_router.py
@@ -3,11 +3,11 @@ from fastapi.responses import RedirectResponse
 from app.services.instructor_service import InstructorNotFoundError
 from domain.dto.instructor.instructor import InstructorDto
 from app.services import InstructorService
-from .middleware import token_extractor, user_id_extractor
+from .middleware import token_validator, user_id_extractor
 
 router = APIRouter(
     prefix="/instructor",
-    dependencies=[Depends(token_extractor), Depends(user_id_extractor)]
+    dependencies=[Depends(token_validator), Depends(user_id_extractor)]
 )
 
 @router.get("/", response_model=InstructorDto)

--- a/src/backend/app/routing/middleware/__init__.py
+++ b/src/backend/app/routing/middleware/__init__.py
@@ -1,1 +1,1 @@
-from .token_middleware import token_extractor, user_id_extractor
+from .token_middleware import token_validator, user_id_extractor

--- a/src/backend/app/routing/middleware/token_middleware.py
+++ b/src/backend/app/routing/middleware/token_middleware.py
@@ -1,14 +1,19 @@
+from typing import Optional
 from fastapi import Depends
 from fastapi.security import OAuth2PasswordBearer
 from app.routing.responses import raise_unauthorized
 from app.utilities.jwt import InvalidJWTToken, decode_token
+from app.services.auth_service import TOKEN_BLACKLIST_SET
+from common.cache import is_in_set_with_expiration
 from config import get_token_secret
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
-def token_extractor(token: str = Depends(oauth2_scheme)) -> dict:
+def token_validator(
+    token: str = Depends(oauth2_scheme)
+) -> dict:
     """
-    Extracts the JWT information from the request token
+    Extracts the JWT information from the request token while also ensuring it is not blacklisted
 
     Args:
         token (str, optional): The token provided in an HTTP request.
@@ -20,11 +25,32 @@ def token_extractor(token: str = Depends(oauth2_scheme)) -> dict:
         dict: The decoded token information
     """
     try:
-        return decode_token(token, get_token_secret())
+        data = decode_token(token, get_token_secret())
+    
+        if is_in_set_with_expiration(TOKEN_BLACKLIST_SET, token):
+            raise_unauthorized()
+            
+        return data
     except InvalidJWTToken:
         raise_unauthorized()
+        
+def get_access_token(token: str = Depends(oauth2_scheme)) -> Optional[str]:
+    """
+    Extracts the access token from the token in the request
+
+    Args:
+        token (str): The token provided in an HTTP request
+
+    Returns:
+        str: The access token
+    """
     
-def user_id_extractor(token: dict = Depends(token_extractor)) -> str:
+    try:
+        return token
+    except InvalidJWTToken:
+        return None
+    
+def user_id_extractor(token: dict = Depends(token_validator)) -> str:
     """
     Extracts the authorized user's ID from the token in the request
 

--- a/src/backend/app/routing/user_router.py
+++ b/src/backend/app/routing/user_router.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, File, Response, UploadFile
-from .middleware import token_extractor, user_id_extractor
+from .middleware import token_validator, user_id_extractor
 from app.services import UserService, UserOnboardingService
 
 from app.utilities.profile import get_user_profile_text
@@ -8,7 +8,7 @@ from domain.dto.user import UserDto
 
 router = APIRouter(
     prefix="/users",
-    dependencies=[Depends(token_extractor), Depends(user_id_extractor)]
+    dependencies=[Depends(token_validator), Depends(user_id_extractor)]
 )
 
 @router.get("/me", response_model=UserDto)

--- a/src/backend/app/routing/validation_router.py
+++ b/src/backend/app/routing/validation_router.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, Depends
-from app.routing.middleware import token_extractor, user_id_extractor
+from app.routing.middleware import token_validator, user_id_extractor
 from app.services import ValidationService
 from .contracts import AssertionResult
 
 router = APIRouter(
     prefix="/validation",
     dependencies=[
-        Depends(token_extractor),
+        Depends(token_validator),
         Depends(user_id_extractor)
     ]
 )

--- a/src/client/src/api/AuthApi.ts
+++ b/src/client/src/api/AuthApi.ts
@@ -13,6 +13,12 @@ class AuthApi extends BaseApi {
     ): Promise<TokenResponse> {
         return this.post("register", { email, username, password });
     }
+
+    logout(): Promise<void> {
+        return this.deleteWithPayload("", {
+            refresh_token: localStorage.getItem("refreshToken"),
+        });
+    }
 }
 
 export default new AuthApi("auth");

--- a/src/client/src/api/BaseApi.ts
+++ b/src/client/src/api/BaseApi.ts
@@ -112,6 +112,16 @@ abstract class BaseApi {
         ).then((r) => r.json());
     }
 
+    protected deleteWithPayload(url: string, data: any): Promise<void> {
+        return this.wrapAuthorization(() =>
+            fetch(`${apiEndpoint}/${this.prefix}/${url}`, {
+                method: "DELETE",
+                headers: this.get_headers(),
+                body: JSON.stringify(data),
+            })
+        ).then(() => {});
+    }
+
     protected deleteWithoutResponse(url: string): Promise<void> {
         return this.wrapAuthorization(() =>
             fetch(`${apiEndpoint}/${this.prefix}/${url}`, {

--- a/src/client/src/context/auth/AuthContext.tsx
+++ b/src/client/src/context/auth/AuthContext.tsx
@@ -11,6 +11,7 @@ type Context = {
         username: string,
         password: string
     ) => Promise<void>;
+    logout: () => void;
     isAuthenticated: boolean;
     userId: string | null;
 };
@@ -18,6 +19,7 @@ type Context = {
 const defaultValue: Context = {
     login: () => Promise.resolve(),
     register: () => Promise.resolve(),
+    logout: () => {},
     isAuthenticated: false,
     userId: null,
 };
@@ -147,6 +149,14 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         );
     };
 
+    const handleLogout = () => {
+        AuthApi.logout().finally(() => {
+            localStorage.removeItem("token");
+            localStorage.removeItem("refreshToken");
+            setIsAuthenticated(false);
+        });
+    };
+
     if (isAuthenticated === null) {
         return (
             <Center h="100vh">
@@ -160,6 +170,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
             value={{
                 login: handleLogin,
                 register: handleRegister,
+                logout: handleLogout,
                 isAuthenticated,
                 userId,
             }}

--- a/src/client/src/context/auth/hooks/index.ts
+++ b/src/client/src/context/auth/hooks/index.ts
@@ -3,3 +3,4 @@ export * from "./useCurrentUserId";
 export * from "./useAuthToken";
 export * from "./useLogin";
 export * from "./useRegistration";
+export * from "./useLogout";

--- a/src/client/src/context/auth/hooks/useLogout.ts
+++ b/src/client/src/context/auth/hooks/useLogout.ts
@@ -1,0 +1,8 @@
+import { useContextSelector } from "use-context-selector";
+import { AuthContext } from "@context/auth";
+
+export const useLogout = () => {
+    const logout = useContextSelector(AuthContext, (v) => v.logout);
+
+    return logout;
+};

--- a/src/client/src/views/dashboard/sections/header/Header.tsx
+++ b/src/client/src/views/dashboard/sections/header/Header.tsx
@@ -4,6 +4,7 @@ import { Menu, Group, Center, Burger } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { IconChevronDown } from "@tabler/icons-react";
 import classes from "./Header.module.css";
+import { useLogout } from "@context/auth";
 
 const links = [
     { link: "/dashboard/courses", label: "Courses" },
@@ -20,17 +21,30 @@ const links = [
         label: "Account",
         links: [
             { link: "/dashboard/account/billing", label: "Billing" },
-            { link: "#", label: "Sign out" },
+            { key: "logout", link: "#", label: "Sign out" },
         ],
     },
 ];
 
 export function Header() {
+    const logout = useLogout();
     const [opened, { toggle }] = useDisclosure(false);
+
+    const getClickAction = (key?: string) => {
+        if (!key) return () => {};
+
+        if (key === "logout") {
+            return logout;
+        }
+
+        return () => {};
+    };
 
     const items = links.map((link) => {
         const menuItems = link.links?.map((item) => (
-            <Menu.Item key={item.link}>{item.label}</Menu.Item>
+            <Menu.Item key={item.link} onClick={getClickAction(item.key)}>
+                {item.label}
+            </Menu.Item>
         ));
 
         if (menuItems) {


### PR DESCRIPTION
This PR adds logout functionality to the application. When a user signs out, a request is made to the backend that will blacklist both their access token and also their refresh token so they can no longer be used. This change comes with some renaming of token middleware methods, the blacklist key in redis. and the name of the payload for the refresh and logout endpoints.

Whether or not the call succeeds, the client will still remove the tokens from the browser and set the authorized state to false.