### PR TITLE
Fix for Lesson View Layout

### DIFF
--- a/src/client/src/components/organisms/course/Lesson.tsx
+++ b/src/client/src/components/organisms/course/Lesson.tsx
@@ -69,7 +69,7 @@ export const Lesson = ({ courseId, lessonId }: LessonProps) => {
                     </Grid.Col>
                 )}
 
-                <Grid.Col span="auto">
+                <Grid.Col span={sections.length === 1 ? 12 : 9}>
                     <Stack>
                         <Group justify="space-between">
                             <Stack gap={0}>


### PR DESCRIPTION
This change fixes a bug where the Lesson view would show the stepper above the main content when it should always be to the left on the same y position.