### PR TITLE
Fix Bug in Resume Scanner for Schools

### DIFF
--- a/src/backend/ai/prompts/resume_scan/resume_scanner_prompt.py
+++ b/src/backend/ai/prompts/resume_scan/resume_scanner_prompt.py
@@ -56,7 +56,7 @@ Ex: If the resume says "May 2020", you will use "2020-05-01" or "2020-05-31" res
             student = UserProfileStudentDto.model_construct(
                 schools=[
                     UserProfileSchoolDto.model_construct(
-                        school_name=school.name,
+                        school_name=school.school_name,
                         focus=school.focus,
                         start_date=school.start_month,
                         end_date=school.end_month,


### PR DESCRIPTION
This PR includes a small typo fix in the resume scanning prompt causing resumes with an education section to fail processing.