### PR TITLE
Add Require Email Validation Flag

### DIFF
--- a/src/backend/app/repositories/user_repository.py
+++ b/src/backend/app/repositories/user_repository.py
@@ -22,7 +22,13 @@ class UserRepository:
     """
     Handles all primary data access for user records in the database
     """
-    async def create_user(self, email_address: str, username: str, password_hash: Optional[str]) -> User:
+    async def create_user(
+        self, 
+        email_address: str, 
+        username: str, 
+        password_hash: Optional[str],
+        set_email_validated: bool = False
+    ) -> User:
         """
         Creates a new ueer record in the database
 
@@ -37,7 +43,8 @@ class UserRepository:
         user = User(
             email=email_address, 
             username=username, 
-            password_hash=password_hash
+            password_hash=password_hash,
+            pending_verification=not set_email_validated
         )
         user.profile = UserProfile()
         

--- a/src/backend/app/services/user_service.py
+++ b/src/backend/app/services/user_service.py
@@ -1,11 +1,11 @@
 import asyncio
 import os
 from typing import List
-import uuid
 
 from fastapi import Depends, UploadFile
 from mimetypes import guess_extension, guess_type
 
+from config import is_email_validation_enabled
 from app.services.user_onboarding_service import UserOnboardingService
 from domain.enums.auth import OAuthProvider
 from domain.dto.profile import UserProfileDto
@@ -28,10 +28,12 @@ class UserService:
     
     onboarding_service: UserOnboardingService
     user_repo: UserRepository
+    is_email_validation_enabled: bool
     
     def __init__(self, user_onboarding_service: UserOnboardingService = Depends(UserOnboardingService), user_repo: UserRepository = Depends(UserRepository)):
         self.onboarding_service = user_onboarding_service
         self.user_repo = user_repo
+        self.is_email_validation_enabled = is_email_validation_enabled()
 
     async def create_user(self, email_address: str, username: str, password_hash: str) -> User:
         """
@@ -63,11 +65,13 @@ class UserService:
         user = await self.user_repo.create_user(
             email_address=email_address, 
             username=username, 
-            password_hash=password_hash
+            password_hash=password_hash,
+            set_email_validated=not self.is_email_validation_enabled
         )
         
         # Begin onboarding with verification
-        await self.onboarding_service.send_verification_email(user.id)
+        if self.is_email_validation_enabled:
+            await self.onboarding_service.send_verification_email(user.id)
         
         return user
     
@@ -104,7 +108,8 @@ class UserService:
         user = await self.user_repo.create_user(
             email_address=email_address,
             username=username,
-            password_hash=None
+            password_hash=None,
+            set_email_validated=True
         )
         
         await self.user_repo.create_external_auth(

--- a/src/backend/app/services/user_service.py
+++ b/src/backend/app/services/user_service.py
@@ -123,9 +123,6 @@ class UserService:
             avatar_url=avatar_url
         )
         
-        # Verify the user since they authenticated with an external provider
-        await self.user_repo.mark_verified(user.id)
-        
         return user
     
     async def get_user(self, by: UserIdentifiers, value: str, include: List[UserIncludes] = ["profile.*"]) -> User:

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -23,7 +23,7 @@ def get_live_reload() -> Boolean:
     return str_value.lower() == "true"
 
 def is_email_validation_enabled() -> bool:
-    return os.getenv("REQUIRE_EMAIL_VALIDATION", "false").lower() == "true"
+    return os.getenv("REQUIRE_EMAIL_VALIDATION", "true").lower() == "true"
 
 # AWS
 def get_aws_access_key() -> str:

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -22,6 +22,9 @@ def get_live_reload() -> Boolean:
     str_value = os.getenv("ENABLE_LIVE_RELOAD", "true")
     return str_value.lower() == "true"
 
+def is_email_validation_enabled() -> bool:
+    return os.getenv("REQUIRE_EMAIL_VALIDATION", "false").lower() == "true"
+
 # AWS
 def get_aws_access_key() -> str:
     return os.getenv("AWS_ACCESS_KEY")

--- a/src/backend/docker-compose.yml
+++ b/src/backend/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - POSTGRES_HOST=database
       - REDIS_HOST=redis
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - REQUIRE_EMAIL_VALIDATION=false
     depends_on:
       - database
       - redis


### PR DESCRIPTION
This change adds a new environment variable to be read by the API: `REQUIRE_EMAIL_VALIDATION`

If set to false, a welcome email will not be sent to a new user. Instead, their account will already be marked as verified. This is mostly intended for local testing purposes, and is therefore defaulted to `true` and set in docker-compose as `false`